### PR TITLE
Backwards compatibility with python2

### DIFF
--- a/color_extractor/resize.py
+++ b/color_extractor/resize.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import numpy as np
 from skimage.transform import resize
 
@@ -37,7 +38,7 @@ class Resize(Task):
         src_h, src_w = img.shape[:2]
         dst_h = self._settings['rows']
         dst_w = int((dst_h / src_h) * src_w)
-        return resize(img, (dst_h, dst_w))
+        return resize(img, (dst_h, dst_w), mode='constant')
 
     def _crop(self, img):
         src_h, src_w = img.shape[:2]


### PR DESCRIPTION
Without importing python3 division resize fails with div by zero on line 40. Also added parameter to resize function, to get rid of the warning of changes in next versions of skimage